### PR TITLE
Remove non-text character from tsconfig.json

### DIFF
--- a/packages/react-scripts/template/tsconfig.json
+++ b/packages/react-scripts/template/tsconfig.json
@@ -28,5 +28,4 @@
   "types": [
     "typePatches"
   ]
-} 
-
+}


### PR DESCRIPTION
Fixes #5. GitHub doesn't show this in the web diff:

```diff
$ git diff HEAD~1
diff --git a/packages/react-scripts/template/tsconfig.json b/packages/react-scripts/template/tsconfig.json
index 171faa0..7127680 100644
--- a/packages/react-scripts/template/tsconfig.json
+++ b/packages/react-scripts/template/tsconfig.json
@@ -28,5 +28,4 @@
   "types": [
     "typePatches"
   ]
-}<U+2028>
-
+}
```