### PR TITLE
Use "compilerOptions" from projects "tsconfig.json" for jest

### DIFF
--- a/packages/react-scripts/config/jest/typescriptTransform.js
+++ b/packages/react-scripts/config/jest/typescriptTransform.js
@@ -1,21 +1,33 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
+const fs = require('fs');
 const tsc = require('typescript');
+const tsconfigPath = require('app-root-path').resolve('/tsconfig.json');
+
+let compilerConfig = {
+  module: tsc.ModuleKind.CommonJS,
+  jsx: tsc.JsxEmit.React,
+}
+
+if (fs.existsSync(tsconfigPath)) {
+  try {
+    const tsconfig = require(tsconfigPath);
+
+    if (tsconfig && tsconfig.compilerOptions) {
+      compilerConfig = tsconfig.compilerOptions;
+    }
+  } catch (e) { /* Do nothing - default is set */ }
+}
 
 module.exports = {
   process(src, path) {
     if (path.endsWith('.ts') || path.endsWith('.tsx')) {
       return tsc.transpile(
         src,
-        {
-          module: tsc.ModuleKind.CommonJS,
-          jsx: tsc.JsxEmit.React,
-        },
-        path,
-        []
+        compilerConfig,
+        path, []
       );
     }
     return src;
   },
 };
-

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -24,6 +24,7 @@
     "react-scripts-ts": "./bin/react-scripts-ts.js"
   },
   "dependencies": {
+    "app-root-path": "^2.0.1",
     "autoprefixer": "6.7.2",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chalk": "1.1.3",


### PR DESCRIPTION
Closes #33 

This enhances the compilation process which compiles typescript to js before all tests in jest are run to apply the compiler-settings from `tsconfig.json` in the project's root-folder instead of the hardcoded defaults.

The defaults still apply, if
* ... no `tsconfig.json` is present
* ... `tsconfig.json` does not contain valid JSON
* ... `tsconfig.json` has no `compilerOptions`

A new dependency is introduced to reliably determine the project-root of the current project, in order to account for different setups and environment. Also refer to this discussion of the problem: http://stackoverflow.com/questions/10265798/determine-project-root-from-a-running-node-js-application

**Test Plan**

* Tested with a test-setup that has failing tests because features that are enabled in the projects `tsconfig.json` are not used in jest-pre-processing => works after the changes
* Tested without a `tsconfig.json` => defaults are used
* Tested with a `tsconfig.json` that contains invalid json or is empty => defaults are used
* Tested with a `tsconfig.json` without `compilerOptions` => defaults are used