### PR TITLE
Fixed compile errors described in issue #53

### DIFF
--- a/packages/react-scripts/template/tsconfig.json
+++ b/packages/react-scripts/template/tsconfig.json
@@ -15,7 +15,8 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Fixes compiler errors described in #53 by adding `"skipLibCheck": true` to `tsconfig.json` compiler options.