### PR TITLE
Update Jest to latest version (20.0.3)

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -39,7 +39,7 @@
     "fs-extra": "0.30.0",
     "html-webpack-plugin": "2.24.0",
     "http-proxy-middleware": "0.17.3",
-    "jest": "18.1.0",
+    "jest": "20.0.3",
     "json-loader": "0.5.4",
     "object-assign": "4.1.1",
     "postcss-loader": "1.2.2",


### PR DESCRIPTION
I ran into an error when testing this, but I think it was because I still had version `18.1.0` of `jest` in the main `node_modules` folder, but version `20.0.3` in the `node_modules/react-scripts-ts/node_modules` folder.  It worked fine when I manually installed `20.0.3` in place of the old version.

I think it will work fine when creating a new app, but I'm not sure whether it will be okay for updating an existing project.

I tried doing `yarn install` after changing the version in `node_modules/react-scripts-ts/package.json`, but that didn't change the version of `jest` installed.

I suspect that bumping the version of `react-scripts-ts` to a version that includes this change would cause the right things to be installed recursively, but I am not sure how to test that.