### PR TITLE
added source-map-loader

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -132,6 +132,12 @@ module.exports = {
         enforce: 'pre',
         include: paths.appSrc,
       },
+      {
+        test: /\.js$/,
+        loader: require.resolve('source-map-loader'),
+        enforce: 'pre',
+        include: paths.appSrc,
+      },
       // ** ADDING/UPDATING LOADERS **
       // The "file" loader handles all assets unless explicitly excluded.
       // The `exclude` list *must* be updated with every change to loader extensions.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -130,6 +130,12 @@ module.exports = {
         enforce: 'pre',
         include: paths.appSrc,
       },
+      {
+        test: /\.js$/,
+        loader: require.resolve('source-map-loader'),
+        enforce: 'pre',
+        include: paths.appSrc,
+      },
       // ** ADDING/UPDATING LOADERS **
       // The "file" loader handles all assets unless explicitly excluded.
       // The `exclude` list *must* be updated with every change to loader extensions.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -47,6 +47,7 @@
     "tslint-loader": "^3.3.0",
     "tslint-react": "^2.0.0",
     "typescript": "^2.3.2",
+    "source-map-loader": "^0.2.1",
     "sw-precache-webpack-plugin": "0.9.1",
     "url-loader": "0.5.8",
     "webpack": "2.5.1",


### PR DESCRIPTION
I've added source-map-loader to the webpack config for development.
This allowed me to successfully use all the VSCode debugging goodness!

Here's the VSCode launch target I made:
```
{
  "version": "0.2.0",
  "configurations": [
    {
      "type": "chrome",
      "request": "launch",
      "name": "Launch Chrome",
      "url": "http://localhost:3000",
      "userDataDir": "${workspaceRoot}/.vscode/chrome",
      "linux": {
        "runtimeExecutable": "chromium-browser"
      },
      "webRoot": "${workspaceRoot}",
      "sourceMaps": true,
      "sourceMapPathOverrides": {
        "webpack:///*": "${workspaceRoot}/*"
      }
    }
  ]
}
```

I saw you working on a CRA 1.0 update which involves a webpack upgrade to v2. I'm fine if you want to wait on this one and I can update the patch after that PR is done. #61 