### PR TITLE
fix(typescriptTransform): Let tsc read the config instead of using 'require'

### DIFF
--- a/packages/react-scripts/config/jest/typescriptTransform.js
+++ b/packages/react-scripts/config/jest/typescriptTransform.js
@@ -9,26 +9,24 @@ const tsconfigPath = require('app-root-path').resolve('/tsconfig.json');
 let compilerConfig = {
   module: tsc.ModuleKind.CommonJS,
   jsx: tsc.JsxEmit.React,
-}
+};
 
 if (fs.existsSync(tsconfigPath)) {
   try {
-    const tsconfig = require(tsconfigPath);
+    const tsconfig = tsc.readConfigFile(tsconfigPath).config;
 
     if (tsconfig && tsconfig.compilerOptions) {
       compilerConfig = tsconfig.compilerOptions;
     }
-  } catch (e) { /* Do nothing - default is set */ }
+  } catch (e) {
+    /* Do nothing - default is set */
+  }
 }
 
 module.exports = {
   process(src, path) {
     if (path.endsWith('.ts') || path.endsWith('.tsx')) {
-      return tsc.transpile(
-        src,
-        compilerConfig,
-        path, []
-      );
+      return tsc.transpile(src, compilerConfig, path, []);
     }
     return src;
   },


### PR DESCRIPTION
Hi there,

I'm currently migrating one of my playground projects to use CRA as a base.
While adopting everything, I've spotted a problem with the typescript transformation process.

Although the `tsconfig` is in JSON format, it may contain the `extends` option for configuration inheritance. In that case, using plain `require` would lead to an unexpected result.

Example:
[tsconfig for dev and build](https://github.com/DorianGrey/react-ts-playground/blob/master/tsconfig.json)
[tsconfig for test](https://github.com/DorianGrey/react-ts-playground/blob/master/tsconfig.test.json)

The config for dev and build uses `module: "es2015"` for tree-shaking, while the one for tests uses `module: "commonjs"`, since the tests won't work with the first option. However, every other option should remain untouched, thus - configuration inheritance.
Using the `readConfigFile` function correctly follows the `extends` reference and thus allows to use different configs for dev/build and test.

(Don't mind that the referenced project does not build correctly (yet), still working on it ...)