### PR TITLE
Allow loading modules from json files

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -26,7 +26,7 @@ module.exports = (resolve, rootDir) => {
     collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,
-    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.ts?(x)',
       '<rootDir>/src/**/?(*.)(spec|test).ts?(x)',


### PR DESCRIPTION
This adds supports for such packages as:

- [`babel-core`](https://github.com/babel/babel/blob/7ca8170/packages/babel-core/src/index.js#L5)
- [`normalize-package-data`](https://github.com/npm/normalize-package-data/blob/d8a6a0c17ccd173c4d83daab7617e1b9ef981e52/lib/fixer.js#L8)

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
