### PR TITLE
Jest cache busting for ts/tsx files

### DIFF
--- a/packages/react-scripts/config/jest/typescriptTransform.js
+++ b/packages/react-scripts/config/jest/typescriptTransform.js
@@ -3,13 +3,15 @@
 'use strict';
 
 const fs = require('fs');
+const crypto = require('crypto');
 const tsc = require('typescript');
 const tsconfigPath = require('app-root-path').resolve('/tsconfig.json');
+const THIS_FILE = fs.readFileSync(__filename);
 
 let compilerConfig = {
   module: tsc.ModuleKind.CommonJS,
   jsx: tsc.JsxEmit.React,
-}
+};
 
 if (fs.existsSync(tsconfigPath)) {
   try {
@@ -18,18 +20,32 @@ if (fs.existsSync(tsconfigPath)) {
     if (tsconfig && tsconfig.compilerOptions) {
       compilerConfig = tsconfig.compilerOptions;
     }
-  } catch (e) { /* Do nothing - default is set */ }
+  } catch (e) {
+    /* Do nothing - default is set */
+  }
 }
 
 module.exports = {
   process(src, path) {
     if (path.endsWith('.ts') || path.endsWith('.tsx')) {
-      return tsc.transpile(
-        src,
-        compilerConfig,
-        path, []
-      );
+      return tsc.transpile(src, compilerConfig, path, []);
     }
     return src;
+  },
+  getCacheKey(fileData, filePath, configStr, options) {
+    return crypto
+      .createHash('md5')
+      .update(THIS_FILE)
+      .update('\0', 'utf8')
+      .update(fileData)
+      .update('\0', 'utf8')
+      .update(filePath)
+      .update('\0', 'utf8')
+      .update(configStr)
+      .update('\0', 'utf8')
+      .update(JSON.stringify(compilerConfig))
+      .update('\0', 'utf8')
+      .update(options.instrument ? 'instrument' : '')
+      .digest('hex');
   },
 };


### PR DESCRIPTION
I noticed some caching issues with Jest cause changes to my tsconfig.json wasn't recognized.

>Jest caches transformed module files to speed up test execution. If you are using your own custom transformer, consider adding a getCacheKey function to it
https://facebook.github.io/jest/docs/troubleshooting.html#caching-issues

This PR adds a cache-key function which generates the key based on:
- the content of the transformer (to be ready for changes in the future)
- the content of the file to transform
- the jest config
- the ts compiler config
- the code-coverage flag

Based on https://github.com/facebook/jest/blob/b254715310d800330479aad6996b4bc0716feaa2/packages/babel-jest/src/index.js#L80