### PR TITLE
Fix code-coverage reports for ts/tsx

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -23,6 +23,7 @@ module.exports = (resolve, rootDir) => {
   // TODO: I don't know if it's safe or not to just use / as path separator
   // in Jest configs. We need help from somebody with Windows to determine this.
   const config = {
+    mapCoverage: true,
     collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,


### PR DESCRIPTION
This PR applys sourcemaps for code-coverage reports.

Before:
```
--------------------------|----------|----------|----------|----------|----------------|
File                      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------------------|----------|----------|----------|----------|----------------|
All files                 |    34.69 |    30.77 |     37.5 |    36.17 |                |
 App.tsx                  |    80.95 |    57.14 |       75 |    89.47 |            4,5 |
 index.tsx                |        0 |      100 |      100 |        0 |2,3,4,5,6,7,8,9 |
 registerServiceWorker.ts |        0 |        0 |        0 |        0 |... 49,50,51,55 |
--------------------------|----------|----------|----------|----------|----------------|
```

After:
```
--------------------------|----------|----------|----------|----------|----------------|
File                      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------------------|----------|----------|----------|----------|----------------|
All files                 |    24.32 |        0 |       20 |    22.22 |                |
 App.tsx                  |      100 |      100 |      100 |      100 |                |
 index.tsx                |        0 |      100 |      100 |        0 |2,3,4,5,6,7,8,9 |
 registerServiceWorker.ts |        0 |        0 |        0 |        0 |... 49,50,51,55 |
--------------------------|----------|----------|----------|----------|----------------|
```