### PR TITLE
Upgrade to typescript 2.4 and ts-loader 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/jest": "^19.2.3",
     "@types/node": "^7.0.21",
-    "@types/react": "^15.0.24",
+    "@types/react": "^15.0.34",
     "@types/react-dom": "^15.5.0",
     "eslint": "3.19.0",
     "husky": "^0.13.2",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,64 +1,64 @@
 {
-	"name": "react-scripts-ts",
-	"version": "2.3.2",
-	"description": "Configuration and scripts for Create React App.",
-	"repository": "wmonk/create-react-app",
-	"license": "BSD-3-Clause",
-	"engines": {
-		"node": ">=6"
-	},
-	"bugs": {
-		"url": "https://github.com/wmonk/create-react-app/issues"
-	},
-	"files": [
-		"bin",
-		"config",
-		"bin",
-		"scripts",
-		"template",
-		"utils"
-	],
-	"bin": {
-		"react-scripts-ts": "./bin/react-scripts-ts.js"
-	},
-	"dependencies": {
-		"autoprefixer": "7.1.0",
-		"app-root-path": "^2.0.1",
-		"case-sensitive-paths-webpack-plugin": "2.0.0",
-		"chalk": "1.1.3",
-		"cli-highlight": "1.1.4",
-		"css-loader": "0.28.1",
-		"dotenv": "4.0.0",
-		"extract-text-webpack-plugin": "2.1.0",
-		"file-loader": "0.11.1",
-		"fs-extra": "3.0.1",
-		"html-webpack-plugin": "2.28.0",
-		"jest": "20.0.3",
-		"object-assign": "4.1.1",
-		"postcss-flexbugs-fixes": "3.0.0",
-		"postcss-loader": "2.0.5",
-		"promise": "7.1.1",
-		"react-dev-utils": "^2.0.1",
-		"react-error-overlay": "^1.0.6",
-		"style-loader": "0.17.0",
-		"ts-loader": "^2.2.1",
-		"tslint": "^5.2.0",
-		"tslint-loader": "^3.5.3",
-		"tslint-react": "^3.0.0",
-		"typescript": "~2.4.0",
-		"source-map-loader": "^0.2.1",
-		"sw-precache-webpack-plugin": "0.9.1",
-		"url-loader": "0.5.8",
-		"webpack": "2.6.0",
-		"webpack-dev-server": "2.4.5",
-		"webpack-manifest-plugin": "1.1.0",
-		"whatwg-fetch": "2.0.3"
-	},
-	"devDependencies": {
-		"react": "^15.5.4",
-		"react-dom": "^15.5.4"
-	},
-	"optionalDependencies": {
-		"fsevents": "1.0.17"
-	}
+  "name": "react-scripts-ts",
+  "version": "2.3.2",
+  "description": "Configuration and scripts for Create React App.",
+  "repository": "wmonk/create-react-app",
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=6"
+  },
+  "bugs": {
+    "url": "https://github.com/wmonk/create-react-app/issues"
+  },
+  "files": [
+    "bin",
+    "config",
+    "bin",
+    "scripts",
+    "template",
+    "utils"
+  ],
+  "bin": {
+    "react-scripts-ts": "./bin/react-scripts-ts.js"
+  },
+  "dependencies": {
+    "autoprefixer": "7.1.0",
+    "app-root-path": "^2.0.1",
+    "case-sensitive-paths-webpack-plugin": "2.0.0",
+    "chalk": "1.1.3",
+    "cli-highlight": "1.1.4",
+    "css-loader": "0.28.1",
+    "dotenv": "4.0.0",
+    "extract-text-webpack-plugin": "2.1.0",
+    "file-loader": "0.11.1",
+    "fs-extra": "3.0.1",
+    "html-webpack-plugin": "2.28.0",
+    "jest": "20.0.3",
+    "object-assign": "4.1.1",
+    "postcss-flexbugs-fixes": "3.0.0",
+    "postcss-loader": "2.0.5",
+    "promise": "7.1.1",
+    "react-dev-utils": "^2.0.1",
+    "react-error-overlay": "^1.0.6",
+    "style-loader": "0.17.0",
+    "ts-loader": "^2.2.1",
+    "tslint": "^5.2.0",
+    "tslint-loader": "^3.5.3",
+    "tslint-react": "^3.0.0",
+    "typescript": "~2.4.0",
+    "source-map-loader": "^0.2.1",
+    "sw-precache-webpack-plugin": "0.9.1",
+    "url-loader": "0.5.8",
+    "webpack": "2.6.0",
+    "webpack-dev-server": "2.4.5",
+    "webpack-manifest-plugin": "1.1.0",
+    "whatwg-fetch": "2.0.3"
+  },
+  "devDependencies": {
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
+  },
+  "optionalDependencies": {
+    "fsevents": "1.0.17"
+  }
 }

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,64 +1,64 @@
 {
-  "name": "react-scripts-ts",
-  "version": "2.3.2",
-  "description": "Configuration and scripts for Create React App.",
-  "repository": "wmonk/create-react-app",
-  "license": "BSD-3-Clause",
-  "engines": {
-    "node": ">=6"
-  },
-  "bugs": {
-    "url": "https://github.com/wmonk/create-react-app/issues"
-  },
-  "files": [
-    "bin",
-    "config",
-    "bin",
-    "scripts",
-    "template",
-    "utils"
-  ],
-  "bin": {
-    "react-scripts-ts": "./bin/react-scripts-ts.js"
-  },
-  "dependencies": {
-    "autoprefixer": "7.1.0",
-    "app-root-path": "^2.0.1",
-    "case-sensitive-paths-webpack-plugin": "2.0.0",
-    "chalk": "1.1.3",
-    "cli-highlight": "1.1.4",
-    "css-loader": "0.28.1",
-    "dotenv": "4.0.0",
-    "extract-text-webpack-plugin": "2.1.0",
-    "file-loader": "0.11.1",
-    "fs-extra": "3.0.1",
-    "html-webpack-plugin": "2.28.0",
-    "jest": "20.0.3",
-    "object-assign": "4.1.1",
-    "postcss-flexbugs-fixes": "3.0.0",
-    "postcss-loader": "2.0.5",
-    "promise": "7.1.1",
-    "react-dev-utils": "^2.0.1",
-    "react-error-overlay": "^1.0.6",
-    "style-loader": "0.17.0",
-    "ts-loader": "^2.0.3",
-    "tslint": "^5.2.0",
-    "tslint-loader": "^3.5.3",
-    "tslint-react": "^3.0.0",
-    "typescript": "~2.3.3",
-    "source-map-loader": "^0.2.1",
-    "sw-precache-webpack-plugin": "0.9.1",
-    "url-loader": "0.5.8",
-    "webpack": "2.6.0",
-    "webpack-dev-server": "2.4.5",
-    "webpack-manifest-plugin": "1.1.0",
-    "whatwg-fetch": "2.0.3"
-  },
-  "devDependencies": {
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
-  },
-  "optionalDependencies": {
-    "fsevents": "1.0.17"
-  }
+	"name": "react-scripts-ts",
+	"version": "2.3.2",
+	"description": "Configuration and scripts for Create React App.",
+	"repository": "wmonk/create-react-app",
+	"license": "BSD-3-Clause",
+	"engines": {
+		"node": ">=6"
+	},
+	"bugs": {
+		"url": "https://github.com/wmonk/create-react-app/issues"
+	},
+	"files": [
+		"bin",
+		"config",
+		"bin",
+		"scripts",
+		"template",
+		"utils"
+	],
+	"bin": {
+		"react-scripts-ts": "./bin/react-scripts-ts.js"
+	},
+	"dependencies": {
+		"autoprefixer": "7.1.0",
+		"app-root-path": "^2.0.1",
+		"case-sensitive-paths-webpack-plugin": "2.0.0",
+		"chalk": "1.1.3",
+		"cli-highlight": "1.1.4",
+		"css-loader": "0.28.1",
+		"dotenv": "4.0.0",
+		"extract-text-webpack-plugin": "2.1.0",
+		"file-loader": "0.11.1",
+		"fs-extra": "3.0.1",
+		"html-webpack-plugin": "2.28.0",
+		"jest": "20.0.3",
+		"object-assign": "4.1.1",
+		"postcss-flexbugs-fixes": "3.0.0",
+		"postcss-loader": "2.0.5",
+		"promise": "7.1.1",
+		"react-dev-utils": "^2.0.1",
+		"react-error-overlay": "^1.0.6",
+		"style-loader": "0.17.0",
+		"ts-loader": "^2.2.1",
+		"tslint": "^5.2.0",
+		"tslint-loader": "^3.5.3",
+		"tslint-react": "^3.0.0",
+		"typescript": "~2.4.0",
+		"source-map-loader": "^0.2.1",
+		"sw-precache-webpack-plugin": "0.9.1",
+		"url-loader": "0.5.8",
+		"webpack": "2.6.0",
+		"webpack-dev-server": "2.4.5",
+		"webpack-manifest-plugin": "1.1.0",
+		"whatwg-fetch": "2.0.3"
+	},
+	"devDependencies": {
+		"react": "^15.5.4",
+		"react-dom": "^15.5.4"
+	},
+	"optionalDependencies": {
+		"fsevents": "1.0.17"
+	}
 }


### PR DESCRIPTION
Ts-loader version 2.2.1 is the minimum version required to work on typescript 2.4.1, see https://github.com/TypeStrong/ts-loader/pull/566 for more details.

---

I'm not sure how I can test or verify my changes. Are there any tests I can run, or anyway to run it in a CRA project?
