### PR TITLE
Read tsconfig content for jest ts-transform correctly

### DIFF
--- a/packages/react-scripts/config/jest/typescriptTransform.js
+++ b/packages/react-scripts/config/jest/typescriptTransform.js
@@ -15,7 +15,8 @@ let compilerConfig = {
 
 if (fs.existsSync(tsconfigPath)) {
   try {
-    const tsconfig = tsc.readConfigFile(tsconfigPath).config;
+    const tsconfig = tsc.readConfigFile(tsconfigPath, name =>
+      tsc.sys.readFile(name)).config;
 
     if (tsconfig && tsconfig.compilerOptions) {
       compilerConfig = tsconfig.compilerOptions;


### PR DESCRIPTION
Hi William,

thanks for your work on create-react-app on getting ts in there 👍.

I've ran into a bug in by using experimentaldecorators in tsconfig by running test and coverage scripts. Build and start tasks run fine while test runs fail with an ts-error related to decorators. 
The jest ts-transform does not respect the tsconfig in my project root. 

Looks like the method signature of `readConfigFile` had changed. Now there are 2 parameters required. I've added the missing fs-read parameter. Without this parameter, the tsconfig const is always empty and the default compilerOptions are used.
The content of the tsconfig file is now correctly read and the compilerOptions are getting respected in the ts-transform task.