### PR TITLE
Use ts-jest instead of custom solution for transforming ts files

### DIFF
--- a/packages/react-scripts/config/jest/typescriptTransform.js
+++ b/packages/react-scripts/config/jest/typescriptTransform.js
@@ -2,65 +2,6 @@
 
 'use strict';
 
-const fs = require('fs');
-const crypto = require('crypto');
-const tsc = require('typescript');
-const tsconfigPath = require('app-root-path').resolve('/tsconfig.json');
-const THIS_FILE = fs.readFileSync(__filename);
+const tsJestPreprocessor = require('ts-jest/preprocessor');
 
-let compilerConfig = {
-  module: tsc.ModuleKind.CommonJS,
-  jsx: tsc.JsxEmit.React,
-};
-
-if (fs.existsSync(tsconfigPath)) {
-  try {
-    const tsconfig = tsc.readConfigFile(tsconfigPath).config;
-
-    if (tsconfig && tsconfig.compilerOptions) {
-      compilerConfig = tsconfig.compilerOptions;
-    }
-  } catch (e) {
-    /* Do nothing - default is set */
-  }
-}
-
-module.exports = {
-  process(src, path, config, options) {
-    if (path.endsWith('.ts') || path.endsWith('.tsx')) {
-      let compilerOptions = compilerConfig;
-      if (options.instrument) {
-        // inline source with source map for remapping coverage
-        compilerOptions = Object.assign({}, compilerConfig);
-        delete compilerOptions.sourceMap;
-        compilerOptions.inlineSourceMap = true;
-        compilerOptions.inlineSources = true;
-        // fix broken paths in coverage report if `.outDir` is set
-        delete compilerOptions.outDir;
-      }
-
-      const tsTranspiled = tsc.transpileModule(src, {
-        compilerOptions: compilerOptions,
-        fileName: path,
-      });
-      return tsTranspiled.outputText;
-    }
-    return src;
-  },
-  getCacheKey(fileData, filePath, configStr, options) {
-    return crypto
-      .createHash('md5')
-      .update(THIS_FILE)
-      .update('\0', 'utf8')
-      .update(fileData)
-      .update('\0', 'utf8')
-      .update(filePath)
-      .update('\0', 'utf8')
-      .update(configStr)
-      .update('\0', 'utf8')
-      .update(JSON.stringify(compilerConfig))
-      .update('\0', 'utf8')
-      .update(options.instrument ? 'instrument' : '')
-      .digest('hex');
-  },
-};
+module.exports = tsJestPreprocessor;

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -60,6 +60,7 @@ module.exports = {
   yarnLockFile: resolveApp('yarn.lock'),
   testsSetup: resolveApp('src/setupTests.ts'),
   appNodeModules: resolveApp('node_modules'),
+  appTsConfig: resolveApp('tsconfig.json'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
 };
@@ -80,6 +81,7 @@ module.exports = {
   yarnLockFile: resolveApp('yarn.lock'),
   testsSetup: resolveApp('src/setupTests.ts'),
   appNodeModules: resolveApp('node_modules'),
+  appTsConfig: resolveApp('tsconfig.json'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
   // These properties only exist before ejecting:
@@ -109,6 +111,7 @@ if (
     yarnLockFile: resolveOwn('template/yarn.lock'),
     testsSetup: resolveOwn('template/src/setupTests.ts'),
     appNodeModules: resolveOwn('node_modules'),
+    appTsConfig: resolveOwn('template/tsconfig.json'),
     publicUrl: getPublicUrl(resolveOwn('package.json')),
     servedPath: getServedPath(resolveOwn('package.json')),
     // These properties only exist before ejecting:

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -41,6 +41,7 @@
     "react-dev-utils": "^2.0.1",
     "react-error-overlay": "^1.0.6",
     "style-loader": "0.17.0",
+    "ts-jest": "^20.0.7",
     "ts-loader": "^2.2.1",
     "tslint": "^5.2.0",
     "tslint-loader": "^3.5.3",

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -45,6 +45,11 @@ module.exports = (resolve, rootDir) => {
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
     },
+    globals: {
+      'ts-jest': {
+        tsConfigFile: paths.appTsConfig,
+      },
+    },
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
Hi there,

as already proposed in https://github.com/wmonk/create-react-app-typescript/pull/99, I'd suggest it'd favorable to use an already existing and maintained preprocessor for typescript files, instead of using a custom solution that attempts to not only do the same, but in the same way as well.

I'm proposing [ts-jest](https://github.com/kulshekhar/ts-jest) for this purpose - already using it in testing and production projects, and it works fine. This PR's intent is to discuss and figure out if ts-jest is suitable for the requirements of this project, or if it'd too much or has some issues that still would need to be fixed before it can be taken into consideration.

Besides, I hope I've found all spots that require to be changed for this adoption...

Replacing the current solution with ts-jest would also replace the work that has already been done on the current typescript transformer. Namely, it would affect the PRs:
Effect: Superseed
- https://github.com/wmonk/create-react-app-typescript/pull/99

Effect: Replace
- https://github.com/wmonk/create-react-app-typescript/pull/75
- https://github.com/wmonk/create-react-app-typescript/pull/79
- https://github.com/wmonk/create-react-app-typescript/pull/80

@zinserjan, as some of these have been provided by you, it'd good if you can a second look for the current ts-jest implementation to match the changes from these PRs in an acceptable way. Esp. the function to create the cache key (see [here](https://github.com/kulshekhar/ts-jest/blob/master/src/preprocessor.ts#L80)) should be of interest.
