### PR TITLE
Remove unneeded React.Component type parameters

### DIFF
--- a/packages/react-scripts/template/src/App.tsx
+++ b/packages/react-scripts/template/src/App.tsx
@@ -3,7 +3,7 @@ import './App.css';
 
 const logo = require('./logo.svg');
 
-class App extends React.Component<{}, {}> {
+class App extends React.Component {
   render() {
     return (
       <div className="App">


### PR DESCRIPTION
TypeScript's new type parameter defaulting makes these unnecessary.

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
