### PR TITLE
Update version numbers of dependencies to match those in create-react…

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts-ts",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Configuration and scripts for Create React App.",
   "repository": "wmonk/create-react-app",
   "license": "BSD-3-Clause",
@@ -22,25 +22,25 @@
     "react-scripts-ts": "./bin/react-scripts-ts.js"
   },
   "dependencies": {
-    "autoprefixer": "7.1.0",
+    "autoprefixer": "7.1.1",
     "app-root-path": "^2.0.1",
-    "case-sensitive-paths-webpack-plugin": "2.0.0",
+    "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
     "cli-highlight": "1.1.4",
-    "css-loader": "0.28.1",
+    "css-loader": "0.28.4",
     "dotenv": "4.0.0",
-    "extract-text-webpack-plugin": "2.1.0",
-    "file-loader": "0.11.1",
+    "extract-text-webpack-plugin": "3.0.0",
+    "file-loader": "0.11.2",
     "fs-extra": "3.0.1",
-    "html-webpack-plugin": "2.28.0",
-    "jest": "20.0.3",
+    "html-webpack-plugin": "2.29.0",
+    "jest": "20.0.4",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.0.0",
-    "postcss-loader": "2.0.5",
-    "promise": "7.1.1",
-    "react-dev-utils": "^2.0.1",
-    "react-error-overlay": "^1.0.6",
-    "style-loader": "0.17.0",
+    "postcss-loader": "2.0.6",
+    "promise": "8.0.1",
+    "react-dev-utils": "^3.0.2",
+    "react-error-overlay": "^1.0.9",
+    "style-loader": "0.18.2",
     "ts-jest": "^20.0.7",
     "ts-loader": "^2.2.1",
     "tslint": "^5.2.0",
@@ -49,10 +49,10 @@
     "typescript": "~2.4.0",
     "source-map-loader": "^0.2.1",
     "sw-precache-webpack-plugin": "0.9.1",
-    "url-loader": "0.5.8",
-    "webpack": "2.6.0",
-    "webpack-dev-server": "2.4.5",
-    "webpack-manifest-plugin": "1.1.0",
+    "url-loader": "0.5.9",
+    "webpack": "3.4.1",
+    "webpack-dev-server": "2.6.1",
+    "webpack-manifest-plugin": "1.2.1",
     "whatwg-fetch": "2.0.3"
   },
   "devDependencies": {
@@ -60,6 +60,6 @@
     "react-dom": "^15.5.4"
   },
   "optionalDependencies": {
-    "fsevents": "1.0.17"
+    "fsevents": "1.1.2"
   }
 }


### PR DESCRIPTION
Bumped the version numbers of packages to match the current version numbers in create-react-app.


anecdotally tested through my own projects by linking the folder and ensuring that the scripts continued to run.

Resolves #129 
