### PR TITLE
Fixed VSCode warning for tslint trailing-comma

### DIFF
--- a/packages/react-scripts/template/tslint.json
+++ b/packages/react-scripts/template/tslint.json
@@ -66,7 +66,7 @@
         "semicolon": [true, "always"],
         "switch-default": true,
 
-        "trailing-comma": false,
+        "trailing-comma": [false],
 
         "triple-equals": [ true, "allow-null-check" ],
         "typedef": [


### PR DESCRIPTION
Incorrect type. Expected "array"
