### PR TITLE
Add “node” to Jest's moduleFileExtensions

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -37,6 +37,7 @@ module.exports = (resolve, rootDir) => {
       'web.jsx',
       'jsx',
       'json',
+      'node',
     ],
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.ts?(x)',
@@ -59,7 +60,7 @@ module.exports = (resolve, rootDir) => {
       'ts-jest': {
         tsConfigFile: paths.appTsTestConfig,
       },
-    }
+    },
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
This is the same issue documented in react-script PR #2738, which has already been merged.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
