### PR TITLE
Add explicit `include` compiler property to tsconfig. Closes #159

### DIFF
--- a/packages/react-scripts/template/tsconfig.json
+++ b/packages/react-scripts/template/tsconfig.json
@@ -17,6 +17,9 @@
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true
   },
+  "include": [
+    "src/**/*"
+  ],
   "exclude": [
     "node_modules",
     "build",


### PR DESCRIPTION
The explicit property declaration is based on comment from:
wmonk/create-react-app-typescript#159 https://git.io/v5hxz
and TS handbook:
https://git.io/v5hxK

I'v recreated issue locally. I've hit the same problem myself when using NG 2 cli some time ago and 3rd party tools that have been adding bower/npm packages (with .ts) into public dir. The use-case of the OP seems reasonable for me.

Thanks!
