### PR TITLE
Absolute paths using `REACT_APP_NODE_PATH` instead of `NODE_PATH`

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -57,7 +57,7 @@ dotenvFiles.forEach(dotenvFile => {
 // https://github.com/facebookincubator/create-react-app/issues/1023#issuecomment-265344421
 // We also resolve them to make sure all tools using them work consistently.
 const appDirectory = fs.realpathSync(process.cwd());
-process.env.NODE_PATH = (process.env.NODE_PATH || '')
+process.env.REACT_APP_NODE_PATH = (process.env.REACT_APP_NODE_PATH || '')
   .split(path.delimiter)
   .filter(folder => folder && !path.isAbsolute(folder))
   .map(folder => path.resolve(appDirectory, folder))

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -85,7 +85,7 @@ module.exports = {
     // https://github.com/facebookincubator/create-react-app/issues/253
     modules: ['node_modules', paths.appNodeModules].concat(
       // It is guaranteed to exist because we tweak it in `env.js`
-      process.env.NODE_PATH.split(path.delimiter).filter(Boolean)
+      process.env.REACT_APP_NODE_PATH.split(path.delimiter).filter(Boolean)
     ),
     // These are the reasonable defaults supported by the Node ecosystem.
     // We also include JSX as a common component filename extension to support

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -89,7 +89,7 @@ module.exports = {
     // https://github.com/facebookincubator/create-react-app/issues/253
     modules: ['node_modules', paths.appNodeModules].concat(
       // It is guaranteed to exist because we tweak it in `env.js`
-      process.env.NODE_PATH.split(path.delimiter).filter(Boolean)
+      process.env.REACT_APP_NODE_PATH.split(path.delimiter).filter(Boolean)
     ),
     // These are the reasonable defaults supported by the Node ecosystem.
     // We also include JSX as a common component filename extension to support

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -11,8 +11,13 @@
 
 const fs = require('fs');
 const chalk = require('chalk');
+const path = require('path');
 const paths = require('../../config/paths');
-const envs = require('../../config/env');
+const getClientEnvironment = require('../../config/env');
+
+// Using development config publicUrl option when injecting environment variables.
+const publicUrl = '';
+getClientEnvironment(publicUrl);
 
 module.exports = (resolve, rootDir) => {
   // Use this instead of `paths.testsSetup` to avoid putting
@@ -42,8 +47,14 @@ module.exports = (resolve, rootDir) => {
     transformIgnorePatterns: [
       '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$',
     ],
-    moduleDirectories: ['node_modules'].concat(
-      process.env.REACT_APP_NODE_PATH.split(paths.appPath).filter(Boolean)
+    moduleDirectories: ['node_modules', paths.appNodeModules].concat(
+      // moduleDirectories uses a relative path
+      // Removing injected full path from REACT_APP_NODE_PATH (from env.js)
+      process.env.REACT_APP_NODE_PATH
+        .split(paths.appPath)
+        .join('')
+        .split(path.delimiter)
+        .filter(Boolean)
     ),
     moduleNameMapper: {
       '^react-native$': 'react-native-web',

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -44,7 +44,7 @@ module.exports = (resolve, rootDir) => {
     ],
     moduleDirectories: ['node_modules'].concat(
       process.env.REACT_APP_NODE_PATH.split(paths.appPath).filter(Boolean)
-		),
+    ),
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
     },

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -12,6 +12,7 @@
 const fs = require('fs');
 const chalk = require('chalk');
 const paths = require('../../config/paths');
+const envs = require('../../config/env');
 
 module.exports = (resolve, rootDir) => {
   // Use this instead of `paths.testsSetup` to avoid putting
@@ -41,6 +42,9 @@ module.exports = (resolve, rootDir) => {
     transformIgnorePatterns: [
       '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$',
     ],
+    moduleDirectories: ['node_modules'].concat(
+      process.env.REACT_APP_NODE_PATH.split(paths.appPath).filter(Boolean)
+		),
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
     },


### PR DESCRIPTION
Aimed to fix #122 

Creating concept to utilize `REACT_APP_` variables in `.env` files to solve the issue of Absolute paths.
