### PR TITLE
Add instructions for custom server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ cd my-app/
 npm start
 ```
 
+## Using with a custom server
+If you have a server from which you plan to serve the React files, just run the install command in your existing project root directory, e.g. with the project name 'client'.  This will create a self-contained React project that you can serve statically.
+
 ## Migration
 
 In general, most upgrades won't require any migration steps to work, but if you experience problems after an upgrade, please file an issue, and we'll add it to the list of migration steps below.


### PR DESCRIPTION
This took me 2-3 hours to fully figure out.  I was trying to figure out how to serve the React files from a custom Hapi server, and there didn't seem to be any easy way to merge the two TS files.

These instructions make it an extremely simple process.  Since I would have loved to have this information earlier, and I expect many users will want to use their own server for serving the files, I think this will be a useful change!

This is the preferred method from this article: https://www.fullstackreact.com/articles/using-create-react-app-with-a-server/

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
