### PR TITLE
Include TypeScript as devDependency in boilerplate output

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -47,7 +47,6 @@
     "tslint": "^5.7.0",
     "tslint-loader": "^3.5.3",
     "tslint-react": "^3.2.0",
-    "typescript": "^2.6.2",
     "url-loader": "0.6.2",
     "webpack": "3.8.1",
     "webpack-dev-server": "2.9.4",
@@ -57,6 +56,9 @@
   "devDependencies": {
     "react": "^15.5.4",
     "react-dom": "^15.5.4"
+  },
+  "peerDependencies": {
+    "typescript": "2.x"
   },
   "optionalDependencies": {
     "fsevents": "1.1.2"

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -109,6 +109,7 @@ module.exports = function(
     '@types/react',
     '@types/react-dom',
     '@types/jest',
+    'typescript',
   ];
 
   console.log(


### PR DESCRIPTION
Closes #85.

This will remove `typescript` from `react-scripts-ts` and instead include it as a `devDependency` in the boilerplate output.

Note that I have added it as a `peerDependency` in `react-scripts-ts`. I think this is the right way to handle it, as users upgrading from 2.x of `react-scripts-ts` would see an `UNMET PEER DEPENDENCY` during an install. However this means that when creating a new app the user will see this: 
![image](https://user-images.githubusercontent.com/6355370/32411403-d305dd26-c196-11e7-99d7-2d27c50fc947.png)

