### PR TITLE
 Add link to typescript User Guide 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Create React apps (with Typescript) with no build configuration.
 
 _Do you know react and want to try out typescript? Or do you know typescript and want to try out react?_ Get all the benefits from `create-react-app` but you use typescript! 🚀
 
-
-
 ## tl;dr
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 Create React apps (with Typescript) with no build configuration.
 
+ * [Getting Started](#tldr) – How to create a new app.
+ * [User Guide](https://github.com/wmonk/create-react-app-typescript/blob/master/packages/react-scripts/template/README.md) – How to develop apps bootstrapped with react scripts ts.
+
 _Do you know react and want to try out typescript? Or do you know typescript and want to try out react?_ Get all the benefits from `create-react-app` but you use typescript! 🚀
+
+
 
 ## tl;dr
 


### PR DESCRIPTION
The User Guide is hidden (I found it only recently), so a link (like on the original create-react-app) helps