### PR TITLE
Update member-ordering rule in tslint config

### DIFF
--- a/packages/react-scripts/template/tslint.json
+++ b/packages/react-scripts/template/tslint.json
@@ -25,9 +25,13 @@
         "max-line-length": [ true, 120 ],
         "member-ordering": [
             true,
-            "public-before-private",
-            "static-before-instance",
-            "variables-before-functions"
+            {
+                "order": [
+                    "public-before-private",
+                    "static-before-instance",
+                    "variables-before-functions"
+                ]
+            }
         ],
         "no-any": true,
         "no-arg": true,


### PR DESCRIPTION
I'm not 100% about this so please double check, but I think that `member-ordering` is meant to be in this format.

VSCode was complaining until I made this change.

I used https://palantir.github.io/tslint/rules/member-ordering/ as a reference.