### PR TITLE
Remove tslint-loader from prod build (again)

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -139,14 +139,6 @@ module.exports = {
       // TODO: Disable require.ensure as it's not a standard language feature.
       // We are waiting for https://github.com/facebookincubator/create-react-app/issues/2176.
       // { parser: { requireEnsure: false } },
-      // First, run the linter.
-      // It's important to do this before Typescript runs.
-      {
-        test: /\.(ts|tsx)$/,
-        loader: require.resolve('tslint-loader'),
-        enforce: 'pre',
-        include: paths.appSrc,
-      },
       {
         test: /\.(js|jsx|mjs)$/,
         loader: require.resolve('source-map-loader'),

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -45,7 +45,6 @@
     "ts-loader": "^2.3.7",
     "tsconfig-paths-webpack-plugin": "^2.0.0",
     "tslint": "^5.7.0",
-    "tslint-loader": "^3.5.3",
     "tslint-react": "^3.2.0",
     "typescript": "^2.6.2",
     "url-loader": "0.6.2",


### PR DESCRIPTION
Just been notified that `tslint-loader` somehow made it into the production config again: https://github.com/wmonk/create-react-app-typescript/pull/165#issuecomment-359329826

This one is not required due to the `fork-ts-checker`.