### PR TITLE
Fix typos in Readme changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ To fix this, create a new file *in the root of the project* called `tsconfig.tes
 
 ## Changelog
 
-### 2.13.0
+### 2.13.0
 * Remove tslint-loader from prod builds - @DorianGrey
 * Include typescript as devDependency in boilerplate - @ianschmitz
 * Document custom module formats - @joshtynjala
-* Fix tscofnig.json - @diabelb
+* Fix tsconfig.json - @diabelb
 
 ### 2.12.0
 * Update typescript to 2.6.2


### PR DESCRIPTION
There was a "fake" space character and a typo.