### PR TITLE
Added the abillity to import js and jsx files with ts-loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,7 @@ language: node_js
 node_js:
   - 6
   - 8
-cache:
-  directories:
-  - node_modules
-  - packages/create-react-app/node_modules
-  - packages/react-scripts/node_modules
+cache: false
 install: true
 script:
  - 'if [ $TEST_SUITE = "simple" ]; then tasks/e2e-simple.sh; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ language: node_js
 node_js:
   - 6
   - 8
-cache: false
+cache:
+  directories:
+  - node_modules
+  - packages/create-react-app/node_modules
+  - packages/react-scripts/node_modules
 install: true
 script:
  - 'if [ $TEST_SUITE = "simple" ]; then tasks/e2e-simple.sh; fi'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "publish": "tasks/release.sh",
     "start": "node packages/react-scripts/scripts/start.js",
     "test": "node packages/react-scripts/scripts/test.js --env=jsdom",
-    "format": "prettier --trailing-comma es5 --single-quote --write 'packages/*/*.js' 'packages/*/!(node_modules)/**/*.js'",
+    "format": "prettier --trailing-comma es5 --single-quote --write \"packages/*/*.js\" \"packages/*/!(node_modules)/**/*.js\"",
     "precommit": "lint-staged"
   },
   "devDependencies": {

--- a/packages/react-scripts/config/jest/babelTransform.js
+++ b/packages/react-scripts/config/jest/babelTransform.js
@@ -1,0 +1,16 @@
+// @remove-file-on-eject
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const babelJest = require('babel-jest');
+
+module.exports = babelJest.createTransformer({
+  presets: [require.resolve('babel-preset-react-app')],
+  babelrc: false,
+});

--- a/packages/react-scripts/config/jest/babelTransform.js
+++ b/packages/react-scripts/config/jest/babelTransform.js
@@ -1,10 +1,9 @@
 // @remove-file-on-eject
 /**
- * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ * Copyright (c) 2014-present, Facebook, Inc.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 'use strict';
 

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -124,7 +124,7 @@ module.exports = {
       // please link the files into your node_modules/ and let module-resolution kick in.
       // Make sure your source files are compiled, as they will not be processed in any way.
       new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
-      new TsconfigPathsPlugin({configFile: paths.appTsConfig})
+      new TsconfigPathsPlugin({ configFile: paths.appTsConfig }),
     ],
   },
   module: {
@@ -158,7 +158,7 @@ module.exports = {
           },
           // Compile .tsx?
           {
-            test: /\.(ts|tsx)$/,
+            test: /\.(ts|tsx|js|jsx)$/,
             include: paths.appSrc,
             use: [
               {

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -156,9 +156,22 @@ module.exports = {
               name: 'static/media/[name].[hash:8].[ext]',
             },
           },
+          {
+            test: /\.(js|jsx|mjs)$/,
+            include: paths.appSrc,
+            loader: require.resolve('babel-loader'),
+            options: {
+              // @remove-on-eject-begin
+              babelrc: false,
+              presets: [require.resolve('babel-preset-react-app')],
+              // @remove-on-eject-end
+              compact: true,
+            },
+          },
+
           // Compile .tsx?
           {
-            test: /\.(ts|tsx|js|jsx)$/,
+            test: /\.(ts|tsx)$/,
             include: paths.appSrc,
             use: [
               {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -160,9 +160,21 @@ module.exports = {
               name: 'static/media/[name].[hash:8].[ext]',
             },
           },
+          {
+            test: /\.(js|jsx|mjs)$/,
+            include: paths.appSrc,
+            loader: require.resolve('babel-loader'),
+            options: {
+              // @remove-on-eject-begin
+              babelrc: false,
+              presets: [require.resolve('babel-preset-react-app')],
+              // @remove-on-eject-end
+              compact: true,
+            },
+          },
           // Compile .tsx?
           {
-            test: /\.(ts|tsx|js|jsx)$/,
+            test: /\.(ts|tsx)$/,
             include: paths.appSrc,
             use: [
               {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -130,7 +130,7 @@ module.exports = {
       // please link the files into your node_modules/ and let module-resolution kick in.
       // Make sure your source files are compiled, as they will not be processed in any way.
       new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
-      new TsconfigPathsPlugin({configFile: paths.appTsConfig})
+      new TsconfigPathsPlugin({ configFile: paths.appTsConfig }),
     ],
   },
   module: {
@@ -162,7 +162,7 @@ module.exports = {
           },
           // Compile .tsx?
           {
-            test: /\.(ts|tsx)$/,
+            test: /\.(ts|tsx|js|jsx)$/,
             include: paths.appSrc,
             use: [
               {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -57,7 +57,8 @@
   },
   "devDependencies": {
     "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react-dom": "^15.5.4",
+    "typescript": "^2.7.1"
   },
   "peerDependencies": {
     "typescript": "2.x"

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "autoprefixer": "7.1.6",
     "babel-jest": "^22.1.0",
+    "babel-loader": "^7.1.2",
     "babel-preset-react-app": "^3.1.1",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -43,7 +43,7 @@
     "source-map-loader": "^0.2.1",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
-    "ts-jest": "^20.0.7",
+    "ts-jest": "22.0.1",
     "ts-loader": "^2.3.7",
     "tsconfig-paths-webpack-plugin": "^2.0.0",
     "tslint": "^5.7.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -56,8 +56,7 @@
   },
   "devDependencies": {
     "react": "^15.5.4",
-    "react-dom": "^15.5.4",
-    "typescript": "^2.6.2"
+    "react-dom": "^15.5.4"
   },
   "peerDependencies": {
     "typescript": "2.x"

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -56,7 +56,8 @@
   },
   "devDependencies": {
     "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react-dom": "^15.5.4",
+    "typescript": "^2.6.2"
   },
   "peerDependencies": {
     "typescript": "2.x"

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -33,7 +33,7 @@
     "fork-ts-checker-webpack-plugin": "^0.2.8",
     "fs-extra": "3.0.1",
     "html-webpack-plugin": "2.29.0",
-    "jest": "20.0.4",
+    "jest": "22.1.4",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "2.0.8",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "autoprefixer": "7.1.6",
+    "babel-jest": "^22.1.0",
+    "babel-preset-react-app": "^3.1.1",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
     "css-loader": "0.28.7",

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -11,7 +11,7 @@ const fs = require('fs');
 const chalk = require('chalk');
 const paths = require('../../config/paths');
 
-module.exports = (resolve, rootDir) => {
+module.exports = (resolve, rootDir, isEjecting) => {
   // Use this instead of `paths.testsSetup` to avoid putting
   // an absolute filename into configuration after ejecting.
   const setupTestsFile = fs.existsSync(paths.testsSetup)
@@ -31,6 +31,9 @@ module.exports = (resolve, rootDir) => {
     testEnvironment: 'node',
     testURL: 'http://localhost',
     transform: {
+      '^.+\\.(js|jsx)$': isEjecting
+        ? '<rootDir>/node_modules/babel-jest'
+        : resolve('config/jest/babelTransform.js'),
       '^.+\\.tsx?$': resolve('config/jest/typescriptTransform.js'),
       '^.+\\.css$': resolve('config/jest/cssTransform.js'),
       '^(?!.*\\.(js|jsx|mjs|css|json)$)': resolve(

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -31,7 +31,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     testEnvironment: 'node',
     testURL: 'http://localhost',
     transform: {
-      '^.+\\.(js|jsx)$': isEjecting
+      '^.+\\.(js|jsx|mjs)$': isEjecting
         ? '<rootDir>/node_modules/babel-jest'
         : resolve('config/jest/babelTransform.js'),
       '^.+\\.tsx?$': resolve('config/jest/typescriptTransform.js'),

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -25,8 +25,8 @@ module.exports = (resolve, rootDir) => {
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [
-      '<rootDir>/src/**/__tests__/**/*.ts?(x)',
-      '<rootDir>/src/**/?(*.)(spec|test).ts?(x)',
+      '<rootDir>/src/**/__tests__/**/*.(j|t)s?(x)',
+      '<rootDir>/src/**/?(*.)(spec|test).(j|t)s?(x)',
     ],
     testEnvironment: 'node',
     testURL: 'http://localhost',
@@ -38,7 +38,7 @@ module.exports = (resolve, rootDir) => {
       ),
     },
     transformIgnorePatterns: [
-      '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|ts|tsx)$'
+      '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|ts|tsx)$',
     ],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',


### PR DESCRIPTION
This PR adds the abillity for ts-loader to also process js and jsx files, and lets Jest pick them up as well.

This is good progress for if you want to migrate a large js app gradually to typescript

I've verified it via running it on a mixed repository:
![image](https://user-images.githubusercontent.com/6381792/35470245-f922e7b0-0345-11e8-858e-f763c2bcb012.png)

and tests:
![image](https://user-images.githubusercontent.com/6381792/35470317-75cdb776-0347-11e8-896c-83a1d25b2423.png)

I'm not sure whether there's a smarter way to test it. I did it by editing the node_modules folder directly in this branch https://github.com/GeeWee/flatris/tree/react-scripts-ts-test

(if you want to test, fetch repo, run yarn install, and then git reset --hard to override)

Closes #230 and #217 

(I also changed the prettier config in package.json as single quotes within double quotes doesn't work on windows)
