### PR TITLE
fix incorrectly mapped code coverage

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -46,6 +46,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
     },
+    mapCoverage: true,
     moduleFileExtensions: [
       'mjs',
       'web.ts',


### PR DESCRIPTION
Reference: #254 

I simply added `mapCoverage: true` to `packages/react-scripts/scripts/utils/createJestConfig.js` in order to correct the HTML display test coverage. I installed my repository in my local npm modules, then ran `create-react-app directory --scripts-version=react-scripts-ts-local --use-npm`, repeated the same steps I used in #254, and the output mapped itself correctly to the source code.