### PR TITLE
fix TSLint

### DIFF
--- a/packages/react-scripts/template/tsconfig.json
+++ b/packages/react-scripts/template/tsconfig.json
@@ -24,6 +24,7 @@
     "acceptance-tests",
     "webpack",
     "jest",
-    "src/setupTests.ts"
+    "src/setupTests.ts",
+    "config"
   ]
 }


### PR DESCRIPTION
When TSLint is linting code, he also lints .js files in config folder, and generate "No valid rules have been specified" error. 
I we exclude config folder from tsconfig.json file, and error is gone.

From [fork-ts-checker-webpack-plugin](https://github.com/Realytics/fork-ts-checker-webpack-plugin/blob/master/src/IncrementalChecker.ts#L235) we can get what files is will be linted. Currently it's all files under src and config folder. Thats because we see error "No valid rules have been specified".
If we exclude config folder from linting, only files under src folder will be linted. And error is gone. :) 
For me it's fixed [#246](https://github.com/wmonk/create-react-app-typescript/issues/246)