### PR TITLE
fix(wepack.config.prod.js): set ecma option for compress and output to 5

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -298,14 +298,19 @@ module.exports = {
     new webpack.DefinePlugin(env.stringified),
     // Minify the code.
     new UglifyJsPlugin({
-      parallel: true,
-      cache: true,
       uglifyOptions: {
-        ecma: 8,
+        parse: {
+          // we want uglify-js to parse ecma 8 code. However we want it to output
+          // ecma 5 compliant code, to avoid issues with older browsers, this is
+          // whey we put `ecma: 5` to the compress and output section
+          // https://github.com/facebook/create-react-app/pull/4234
+          ecma: 8,
+        },
         compress: {
+          ecma: 5,
           warnings: false,
           // Disabled because of an issue with Uglify breaking seemingly valid code:
-          // https://github.com/facebookincubator/create-react-app/issues/2376
+          // https://github.com/facebook/create-react-app/issues/2376
           // Pending further investigation:
           // https://github.com/mishoo/UglifyJS2/issues/2011
           comparisons: false,
@@ -314,15 +319,20 @@ module.exports = {
           safari10: true,
         },
         output: {
+          ecma: 5,
           comments: false,
           // Turned on because emoji and regex is not minified properly using default
-          // https://github.com/facebookincubator/create-react-app/issues/2488
+          // https://github.com/facebook/create-react-app/issues/2488
           ascii_only: true,
         },
       },
+      // Use multi-process parallel running to improve the build speed
+      // Default number of concurrent runs: os.cpus().length - 1
+      parallel: true,
+      // Enable file caching
+      cache: true,
       sourceMap: shouldUseSourceMap,
-    }),
-    // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
+    }),    // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
     new ExtractTextPlugin({
       filename: cssFilename,
     }),


### PR DESCRIPTION
The current configuration of UglifyJS breaks in IE11 under specific circumstances.

https://github.com/wmonk/create-react-app-typescript/commit/39d6c62788140ce2ef5acaa8310779d56a7523d4

I simply copied the configuration of the create-react-app master (not yet merged) and tested it works just fine.

https://medium.com/@_meandmax_/react-16-cra-and-ie11-giving-me-headaches-c8be43b4fcb2

Here is the link to the discussion in CRA where you can also find the configuration:
https://github.com/facebook/create-react-app/pull/4234

Was not so sure if this is the right way to do this, but 2.14 breaks in IE11.
