### PR TITLE
Respect explicitly set --watchAll, and favor it over --watch

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -26,8 +26,12 @@ require('../config/env');
 const jest = require('jest');
 const argv = process.argv.slice(2);
 
-// Watch unless on CI or in coverage mode
-if (!process.env.CI && argv.indexOf('--coverage') < 0) {
+// Watch unless on CI, in coverage mode, or explicitly running all tests
+if (
+  !process.env.CI &&
+  argv.indexOf('--coverage') === -1 &&
+  argv.indexOf('--watchAll') === -1
+) {
   argv.push('--watch');
 }
 


### PR DESCRIPTION
Provides a workaround for https://github.com/wmonk/create-react-app-typescript/issues/282 by not adding the `--watch` flag to the arguments provided to `jest` in case `--watchAll` was provided. 

This still has to be applied manually, since it is only required in case of not using `git` or `hg` for version control.