### PR TITLE
fix(modules): remove duplicate mjs from jest config

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -47,7 +47,6 @@ module.exports = (resolve, rootDir, isEjecting) => {
       '^react-native$': 'react-native-web',
     },
     moduleFileExtensions: [
-      'mjs',
       'web.ts',
       'ts',
       'web.tsx',


### PR DESCRIPTION
Fixes #287. This issue manifests for us as `iterall` not being transpiled, leading to `unexpected token export` errors etc. Related issues:

* https://github.com/facebook/create-react-app/pull/4085
* https://github.com/leebyron/iterall/issues/43