### PR TITLE
Stick @types/node to 9.6.7 to avoid problems with 10.0.0

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -105,7 +105,7 @@ module.exports = function(
 
   // Install dev dependencies
   const types = [
-    '@types/node',
+    '@types/node@9.6.7',
     '@types/react',
     '@types/react-dom',
     '@types/jest',


### PR DESCRIPTION
`@types/node 10.0.0` broke the travis build (again), since it causes collisions with typescripts own definitions. Stick with 9.6.7 for now will hopefully fix this... 

Refers to: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/25342
Restriction should be retained until this issue gets resolved.