### PR TITLE
Travis build/e2e-kitchensink: Outstanding behavior fixes...

### DIFF
--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -160,7 +160,10 @@ E2E_FILE=./build/index.html \
 # ******************************************************************************
 
 # Eject...
-echo yes | npm run eject
+echo yes | yarn eject
+
+# Ensure all packages are installed properly.
+yarn
 
 # Link to test module
 npm link "$temp_module_path/node_modules/test-integrity"


### PR DESCRIPTION
Just another attempt...

Current problem: the `e2e-kitchensink` task fails on testing the `eject` command, since `babel-loader` does not seem to be installed after ejection, even though the log mentions that it was added properly.

This might have something to do with a mix of `npm run` and `yarn`... but I'm still inspecting this further.

€dit: 
- ~~Workaround seems to be to force a `yarn install` before building ...yay.~~
- ~~Next error to solve: `Module not found: Error: Can't resolve 'absoluteLoad' in '/tmp/tmp.ji4bCBWZ7D/test-kitchensink/src/features/env'`.~~

€dit#2:
- ~~Next error to fix: `TypeError: (0 , _testIntegrity.version) is not a function` raised in `src/features/webpack/LinkedModules.test.js`~~
- ~~There is a module named `test-integrity` which gets linked during the test. However, it does not seem to be in the expected format. Attempting to use `yarn` instead of `npm` to link it results in a `module not found` error.~~

€dit#3:
Seems that the dependency installation for the ejected projected has to happend before the `npm link` for `test-integrity` - otherwise, an outdated version is installed which does not match the one expected in the test. After having this pointed out, the updated suite seems to work fine - finally!