### PR TITLE
Revert "Stick @types/node to 9.6.7 to avoid problems with 10.0.0"

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -105,7 +105,7 @@ module.exports = function(
 
   // Install dev dependencies
   const types = [
-    '@types/node@9.6.7',
+    '@types/node',
     '@types/react',
     '@types/react-dom',
     '@types/jest',


### PR DESCRIPTION
Reverts wmonk/create-react-app-typescript#315

The typing issue regarding `URL` and `URLSearchParams` have been resolved in the most recent versions of the 10.x branch, so this pin is no longer required.