### PR TITLE
Exclude coverage directory from tsconfig.json

### DIFF
--- a/packages/react-scripts/template/tsconfig.json
+++ b/packages/react-scripts/template/tsconfig.json
@@ -21,6 +21,7 @@
   "exclude": [
     "node_modules",
     "build",
+    "coverage",
     "scripts",
     "acceptance-tests",
     "webpack",


### PR DESCRIPTION
As #340, `coverage` directory may contain `.js` files.


<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->