### PR TITLE
fix: do not add ESLint config to ejected app

### DIFF
--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -208,12 +208,6 @@ inquirer
       presets: ['react-app'],
     };
 
-    // Add ESlint config
-    console.log(`  Adding ${cyan('ESLint')} configuration`);
-    appPackage.eslintConfig = {
-      extends: 'react-app',
-    };
-
     fs.writeFileSync(
       path.join(appPath, 'package.json'),
       JSON.stringify(appPackage, null, 2) + '\n'


### PR DESCRIPTION
Otherwise we get:
`Error while running ESLint: Cannot find module 'eslint-config-react-app'`

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
