### PR TITLE
Allow TypeScript 3 as a peer dependency

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -32,7 +32,7 @@
     "dotenv-expand": "4.2.0",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "0.11.2",
-    "fork-ts-checker-webpack-plugin": "^0.2.8",
+    "fork-ts-checker-webpack-plugin": "^0.4.4",
     "fs-extra": "3.0.1",
     "html-webpack-plugin": "2.29.0",
     "jest": "22.4.2",
@@ -46,7 +46,7 @@
     "resolve": "1.6.0",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
-    "ts-jest": "22.0.1",
+    "ts-jest": "23.1.0",
     "ts-loader": "^2.3.7",
     "tsconfig-paths-webpack-plugin": "^2.0.0",
     "tslint": "^5.7.0",
@@ -62,10 +62,10 @@
   "devDependencies": {
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
-    "typescript": "^2.7.1"
+    "typescript": "^3.0.1"
   },
   "peerDependencies": {
-    "typescript": "2.x"
+    "typescript": "2.x || 3.x"
   },
   "optionalDependencies": {
     "fsevents": "^1.1.3"


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
- Fix #373 by updating minimum dependency versions and own own peer dependencies to allow TS 3. You may want to delete our own peer dependency entire to make this easier in the future, if TS isn't imported directly.
- Use TS 3 in development. This isn't required, but it has major improvements to errors, along with a few type system and build system features you may want to use in the future.

## Verification
- `yarn` and `yarn create-react-app` no longer have peer dependency warnings for react-scripts-ts, ts-jest, and fork-ts-checker-webpack-plugin.
- CRA-TS already works without this change, it's just fixing peer dependency warnings, so this should have the same behavior ignoring peer dependencies.