### PR TITLE
fix: TypeError in production build when targeting ES2015

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -315,6 +315,9 @@ module.exports = {
           // Pending further investigation:
           // https://github.com/mishoo/UglifyJS2/issues/2011
           comparisons: false,
+          // Don't inline functions with arguments, to avoid name collisions:
+          // https://github.com/mishoo/UglifyJS2/issues/2842
+          inline: 1,
         },
         mangle: {
           safari10: true,


### PR DESCRIPTION
Fixes #346.

This is a workaround for [a bug in uglifyjs2](https://github.com/mishoo/UglifyJS2/issues/2842), which can cause name collisions when a function with arguments is inlined. This can result in an unintended shadowing of a `var` or `let`, or a `TypeError: Assignment to constant variable` in case of a `const`.

I reproduced the issue by creating a new app (`create-react-app --scripts-version=react-scripts-ts`), changing `tsconfig.json` like so:

```diff
-    "target": "es5",
-    "lib": ["es6", "dom"],
+    "target": "es6",
```

...and running `yarn build && npx http-server build`.

I then confirmed the fix works by using my local build of `react-scripts-ts`:

```diff
   "dependencies": {
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
-    "react-scripts-ts": "2.17.0"
+    "react-scripts-ts": "../create-react-app-typescript/packages/react-scripts"

```

...and running `yarn && yarn build && npx http-server build`.

Note: this fix increased the boilerplate's un-gzipped JS bundle size from `115969` to `116059` bytes.