### PR TITLE
Ignore test coverage for definitions files 

### DIFF
--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -23,7 +23,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
   const config = {
     collectCoverageFrom: [
       'src/**/*.{js,jsx,ts,tsx}',
-      "!**/*.d.ts"
+      '!**/*.d.ts'
     ],
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,

--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -21,7 +21,10 @@ module.exports = (resolve, rootDir, isEjecting) => {
   // TODO: I don't know if it's safe or not to just use / as path separator
   // in Jest configs. We need help from somebody with Windows to determine this.
   const config = {
-    collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
+    collectCoverageFrom: [
+      'src/**/*.{js,jsx,ts,tsx}',
+      "!**/*.d.ts"
+    ],
     setupFiles: [resolve('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [


### PR DESCRIPTION
# Why?

Typical situation when ts project has extra declaration files (for json, css, some packages w/o types etc). And when you try to get coverage from your tests you will see definitions files as well (`*.d.ts`).
We need to ignore it.

# Demo

## Before

![image](https://user-images.githubusercontent.com/209313/46146335-2b630900-c26b-11e8-8816-62fdf8adbcbf.png)

## After
![image](https://user-images.githubusercontent.com/209313/46146384-52b9d600-c26b-11e8-90fc-4f5b096af145.png)
