### PR TITLE
fix: css-module support about 'keyframes logo-spin'

### DIFF
--- a/template/images.d.ts
+++ b/template/images.d.ts
@@ -5,6 +5,19 @@ declare module '*.jpeg'
 declare module '*.gif'
 declare module '*.bmp'
 declare module '*.tiff'
+
+declare module '*.module.css' {
+  const exports: { [exportName: string]: string };
+  export = exports;
+}
+declare module '*.module.scss' {
+  const exports: { [exportName: string]: string };
+  export = exports;
+}
+declare module '*.module.sass' {
+  const exports: { [exportName: string]: string };
+  export = exports;
+}
 declare module '*.css'
 declare module '*.scss'
 declare module '*.sass'

--- a/template/src/App.module.css
+++ b/template/src/App.module.css
@@ -1,13 +1,13 @@
-:local .app {
+.app {
   text-align: center;
 }
 
-:local .logo {
+.logo {
   animation: logo-spin infinite 20s linear;
   height: 40vmin;
 }
 
-:local .header {
+.header {
   background-color: #282c34;
   min-height: 100vh;
   display: flex;
@@ -18,7 +18,7 @@
   color: white;
 }
 
-:local .link {
+.link {
   color: #61dafb;
 }
 

--- a/template/src/App.tsx
+++ b/template/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as styles from './App.css';
+import * as styles from './App.module.css';
 import logo from './logo.svg';
 
 class App extends React.Component {


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

1. fix error about `@keyframes logo-spin`
1. In order to maintain the same behavior as the [create-react-app](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-a-css-modules-stylesheet), we need use `App.module.css` rather than using `App.css` to enable css-module
1. add `*.module.css` type definition