### PR TITLE
chore: update ts-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "resolve": "1.6.0",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
-    "ts-jest": "22.0.1",
+    "ts-jest": "^23.10.4",
     "ts-loader": "^2.3.7",
     "tsconfig-paths-webpack-plugin": "^2.0.0",
     "tslint": "^5.7.0",


### PR DESCRIPTION
Supersedes #399 without the `package-lock.json` file. Fixes #359.