### PR TITLE
Create global.d.ts

### DIFF
--- a/template/src/global.d.ts
+++ b/template/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';


### PR DESCRIPTION
CSS modules can't work without this file, the 'Cannot find module './xxx.module.scss'.' error is thrown without it

To reproduce the error: simply follow the first instructions of the [official guide](https://facebook.github.io/create-react-app/docs/adding-a-css-modules-stylesheet#docsNav), the error is thrown as soon as the CSS module is imported
